### PR TITLE
Use cp instead of dd

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         </h2>
         <h5><hr width=60%>You were going to install nonfree wifi firmware <em>anyway</em>. Disagree? <a href="https://www.debian.org/distrib/">Have fun here</a>.</h5>
         And don't forget:<br>
-        <code>dd if=&lt;iso_file_name_here&gt; of=/dev/sd&lt;your_usb_key_dev_id&gt; bs=4M; sync</code>
+        <code>cp iso_file_name_here dev/sd&lt;your_usb_key_dev_id&gt; ; sync</code>
        <BR><BR>
 	     <div id="gh"><a href="https://github.com/fiendish/The-Debian-Gotham-Needs">Star&nbsp;me&nbsp;on&nbsp;GitHub, lol</a></div>
         <BR>


### PR DESCRIPTION
* cp (or piping with your shell) will use the most appropriate buffer size for the device; 4M is arbitrary and is probably not the optimal size. This is the recommended method from the Debian Installation Guide.